### PR TITLE
added "offline-first" caching strategy for static assets

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,3 @@
-self.addEventListener("fetch", () => {});
-
 // from https://web.dev/learn/pwa/caching/
 
 const urlsToCache = [

--- a/sw.js
+++ b/sw.js
@@ -1,1 +1,30 @@
 self.addEventListener("fetch", () => {});
+
+// from https://web.dev/learn/pwa/caching/
+
+const urlsToCache = [
+    "/",
+    "bahnhofstafelsuche.webmanifest",
+    "favicon.ico",
+    "icon-192.png",
+    "stops.csv",
+    "turbocommons-es5.js",
+];
+
+self.addEventListener("install", event => {
+    event.waitUntil(
+        caches.open("pwa-assets")
+            .then(cache => {
+                return cache.addAll(urlsToCache);
+            })
+    );
+});
+
+self.addEventListener("fetch", event => {
+    event.respondWith(
+        caches.match(event.request)
+            .then(cachedResponse => {
+                return cachedResponse || fetch(event.request);
+            })
+    );
+});


### PR DESCRIPTION
- open website in chrome
- open devtools
- go to "application" tab
- go to "service worker" sub-tab
- (if service worker is registered, click "unregister" and reload the page)
- check the "offline" checkbox
- reload the page
> the page should be available, including stops data, for local offline usage